### PR TITLE
Fix for duplicate controller names in different areas

### DIFF
--- a/src/EndpointHelpers/LinkGeneratorGenerator.cs
+++ b/src/EndpointHelpers/LinkGeneratorGenerator.cs
@@ -43,7 +43,9 @@ public sealed class LinkGeneratorGenerator : ControllerGeneratorBase
         foreach (var controller in selectedControllers)
         {
             var controllerName = controller.Name.Replace("Controller", string.Empty);
-            var helperClassName = $"{controller.Name}LinkGenerator";
+            var helperClassName = controller.AreaName is { Length: > 0 }
+                ? $"{controller.AreaName}Area{controller.Name}LinkGenerator"
+                : $"{controller.Name}LinkGenerator";
 
             sb.AppendLine($"public sealed class {helperClassName}(LinkGenerator linkGenerator)");
             sb.AppendLine("{");
@@ -124,7 +126,7 @@ public sealed class LinkGeneratorGenerator : ControllerGeneratorBase
 
             foreach (var controller in areaGroup.OrderBy(static controller => controller.MetadataName, StringComparer.Ordinal))
             {
-                var helperClassName = $"{controller.Name}LinkGenerator";
+                var helperClassName = $"{areaIdentifier}Area{controller.Name}LinkGenerator";
                 var propertyName = controller.Name.Replace("Controller", string.Empty);
 
                 sb.AppendLine($"    public {helperClassName} {propertyName} => new {helperClassName}(linkGenerator);");

--- a/src/EndpointHelpers/UrlHelperGenerator.cs
+++ b/src/EndpointHelpers/UrlHelperGenerator.cs
@@ -133,7 +133,9 @@ public sealed class UrlHelperGenerator : ControllerGeneratorBase
         foreach (var controller in selectedControllers)
         {
             var controllerName = controller.Name.Replace("Controller", string.Empty);
-            var helperClassName = $"{controller.Name}UrlHelper";
+            var helperClassName = controller.AreaName is { Length: > 0 }
+                ? $"{controller.AreaName}Area{controller.Name}UrlHelper"
+                : $"{controller.Name}UrlHelper";
 
             sb.AppendLine($"public sealed class {helperClassName}(IUrlHelper url)");
             sb.AppendLine("{");
@@ -193,7 +195,7 @@ public sealed class UrlHelperGenerator : ControllerGeneratorBase
 
             foreach (var controller in areaGroup.OrderBy(static controller => controller.MetadataName, StringComparer.Ordinal))
             {
-                var helperClassName = $"{controller.Name}UrlHelper";
+                var helperClassName = $"{areaIdentifier}Area{controller.Name}UrlHelper";
                 var propertyName = controller.Name.Replace("Controller", string.Empty);
 
                 if (hasJetbrainsAnnotations)

--- a/test/EndpointHelpers.Tests/LinkGeneratorGeneratorTests.cs
+++ b/test/EndpointHelpers.Tests/LinkGeneratorGeneratorTests.cs
@@ -98,8 +98,9 @@ public sealed class LinkGeneratorGeneratorTests
         var generated = Run(AreaControllerSource);
 
         Assert.Contains("public sealed class AdminAreaLinkGenerator(LinkGenerator linkGenerator)", generated);
-        Assert.Contains("public UsersControllerLinkGenerator Users", generated);
+        Assert.Contains("public AdminAreaUsersControllerLinkGenerator Users", generated);
         Assert.Contains("public AdminAreaLinkGenerator Admin", generated);
+        Assert.Contains("=> new AdminAreaUsersControllerLinkGenerator(linkGenerator);", generated);
     }
 
     [Fact]

--- a/test/EndpointHelpers.Tests/UrlHelperGeneratorTests.cs
+++ b/test/EndpointHelpers.Tests/UrlHelperGeneratorTests.cs
@@ -87,7 +87,7 @@ public sealed class UrlHelperGeneratorTests
     {
         var generated = Run();
 
-        Assert.Contains("public sealed class HomeControllerUrlHelper(IUrlHelper url)", generated);
+        Assert.Contains("public sealed class AdminAreaHomeControllerUrlHelper(IUrlHelper url)", generated);
     }
 
     [Fact]
@@ -125,9 +125,9 @@ public sealed class UrlHelperGeneratorTests
         var generated = Run();
 
         Assert.Contains("public sealed class AdminAreaUrlHelper(IUrlHelper url)", generated);
-        Assert.Contains("public HomeControllerUrlHelper Home", generated);
+        Assert.Contains("public AdminAreaHomeControllerUrlHelper Home", generated);
         Assert.Contains("public AdminAreaUrlHelper Admin", generated);
-        Assert.Contains("=> new HomeControllerUrlHelper(url);", generated);
+        Assert.Contains("=> new AdminAreaHomeControllerUrlHelper(url);", generated);
     }
 
     [Fact]


### PR DESCRIPTION
Hi, 

Thanks for creating this project, I was looking for a modern alternative to T4MVC and R4MVC, and this looks perfect.

I noticed this problem when using the library in a big pre-existing project. If two areas have a controller with the same name, the generated files end up with two classes with the same name and the compiler throws various errors:

```
Error CS0101 : The namespace 'EndpointHelpers' already contains a definition for 'AccountControllerLinkGenerator'
Error CS0111 : Type 'AccountControllerLinkGenerator' already defines a member called 'GetChangePasswordPath' with the same parameter types
Error CS0111 : Type 'AccountControllerUrlHelper' already defines a member called 'Edit' with the same parameter types
```

This PR suggests changing the generation to include the name of the area before the name of the controller for controllers inside areas. e.g.

`AdminAreaAccountControllerLinkGenerator` and `AdminAreaAccountControllerUrlHelper` for an `AccountController` in the admin area, so it doesn't conflict with an `AccountController` in another area.

Thanks for reviewing!

Edit: tests have been updated and are all passing